### PR TITLE
Add env to testCases

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,64 @@ If the environment variable `FOO` is not set, cfft exits with a non-zero status 
 
 See [examples/true-client-ip](examples/true-client-ip) directory to see how to use the template syntax.
 
+```yaml
+testCases:
+  - name: localhost
+    event: event.json
+    expect: expect.json
+    env:
+      IP: 127.0.0.1
+      HOSTNAME: localhost
+  - name: home
+    event: event.json
+    expect: expect.json
+    env:
+      IP: 192.168.1.1
+      HOSTNAME: home
+```
+
+In `testCases`, `env` overrides the environment variables. These values are used in `event.json` and `expect.json`.
+
+event.json
+```json
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "{{ env `IP` `127.0.0.2` }}"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/index.html",
+        "headers": {},
+        "cookies": {},
+        "querystring": {}
+    }
+}
+```
+
+expect.json
+```json
+{
+    "request": {
+        "cookies": {},
+        "headers": {
+            "true-client-ip": {
+                "value": "{{ env `IP` `127.0.0.2` }}"
+            },
+            "x-hostname": {
+                "value": "{{ env `HOSTNAME` `unknown` }}"
+            }
+        },
+        "method": "GET",
+        "querystring": {},
+        "uri": "/index.html"
+    }
+}
+```
+
 ## LICENSE
 
 MIT

--- a/examples/true-client-ip/cfft.yaml
+++ b/examples/true-client-ip/cfft.yaml
@@ -4,3 +4,15 @@ testCases:
   - name: default
     event: event.json
     expect: expect.json
+  - name: localhost
+    event: event.json
+    expect: expect.json
+    env:
+      IP: 127.0.0.1
+      HOSTNAME: localhost
+  - name: home
+    event: event.json
+    expect: expect.json
+    env:
+      IP: 192.168.1.1
+      HOSTNAME: home

--- a/examples/true-client-ip/expect.json
+++ b/examples/true-client-ip/expect.json
@@ -4,6 +4,9 @@
         "headers": {
             "true-client-ip": {
                 "value": "{{ env `IP` `127.0.0.2` }}"
+            },
+            "x-hostname": {
+                "value": "{{ env `HOSTNAME` `unknown` }}"
             }
         },
         "method": "GET",

--- a/examples/true-client-ip/function.js
+++ b/examples/true-client-ip/function.js
@@ -1,6 +1,15 @@
+import cf from 'cloudfront';
+const hostnames = {
+  '127.0.0.1': 'localhost',
+  '192.168.1.1': 'home',
+}
+
 async function handler(event) {
   const request = event.request;
   const clientIP = event.viewer.ip;
+  const hostname = hostnames[clientIP] || 'unknown';
+
   request.headers['true-client-ip'] = { value: clientIP };
+  request.headers['x-hostname'] = { value: hostname };
   return request;
 }


### PR DESCRIPTION
In `testCases`, `env` overrides the environment variables. These values are used in `event.json` and `expect.json`.
