### PR TITLE
use CloudFront KeyValueStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,48 @@ $ cfft diff
  }
 ```
 
+### Use CloudFront KeyValueStore
+
+cfft supports [CloudFront KeyVakueStore](https://docs.aws.amazon.com/ja_jp/AmazonCloudFront/latest/DeveloperGuide/kvs-with-functions.html).
+
+```yaml
+# cfft.yaml
+name: function-with-kvs
+function: function.js
+kvs:
+  name: hostnames
+```
+
+If you specify the `kvs` element in the config file, cfft creates a KeyValueStore with the name, if not exsites, and associates the KeyValueStore with the function. You can use the KeyValueStore in the function code.
+
+In a function code, the KVS id is available in the `KVS_ID` environment variable.
+
+```js
+import cf from 'cloudfront';
+
+const kvsId = "{{ must_env `KVS_ID` }}";
+const kvsHandle = cf.kvs(kvsId);
+
+async function handler(event) {
+  const request = event.request;
+  const clientIP = event.viewer.ip;
+  const hostname = (await kvsHandle.exists(clientIP)) ? await kvsHandle.get(clientIP) : 'unknown';
+
+  request.headers['x-hostname'] = { value: hostname };
+  return request;
+}
+```
+
+#### Manage KVS key values with `cfft kvs` command
+
+`cfft kvs` command manages KVS key values.
+
+- `cfft kvs list` lists all key values.
+- `cfft kvs get <key>` gets the value of the key.
+- `cfft kvs put <key> <value>` puts the value of the key.
+- `cfft kvs delete <key>` deletes the key.
+- `cfft kvs info` shows the information of the KeyValueStore.
+
 ### Publish function
 
 `cfft publish` publishes the function to the CloudFront Functions.

--- a/README.md
+++ b/README.md
@@ -267,24 +267,6 @@ cfft supports the following file extensions.
 - .yaml
 - .yml
 
-### Diff function code
-
-`cfft diff` compares the function code with the code in the CloudFront Functions.
-
-```console
-$ cfft diff
-2023/12/23 17:57:17 [info] function cfft found
---- E3UN6WX5RRO2AG
-+++ function.js
-@@ -1,5 +1,5 @@
- async function handler(event) {
-   const request = event.request;
--  console.log('hello cfft world');
-+  console.log('hello cfft');
-   return request;
- }
-```
-
 ### Use CloudFront KeyValueStore
 
 cfft supports [CloudFront KeyVakueStore](https://docs.aws.amazon.com/ja_jp/AmazonCloudFront/latest/DeveloperGuide/kvs-with-functions.html).
@@ -326,6 +308,24 @@ async function handler(event) {
 - `cfft kvs put <key> <value>` puts the value of the key.
 - `cfft kvs delete <key>` deletes the key.
 - `cfft kvs info` shows the information of the KeyValueStore.
+
+### Diff function code
+
+`cfft diff` compares the function code with the code in the CloudFront Functions.
+
+```console
+$ cfft diff
+2023/12/23 17:57:17 [info] function cfft found
+--- E3UN6WX5RRO2AG
++++ function.js
+@@ -1,5 +1,5 @@
+ async function handler(event) {
+   const request = event.request;
+-  console.log('hello cfft world');
++  console.log('hello cfft');
+   return request;
+ }
+```
 
 ### Publish function
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ Commands:
   publish
     publish function
 
+  kvs list
+    list key values
+
+  kvs get <key>
+    get value of key
+
+  kvs put <key> <value>
+    put value of key
+
+  kvs delete <key>
+    delete key
+
+  kvs info
+    show info of key value store
+
   version
     show version
 

--- a/cfft.go
+++ b/cfft.go
@@ -47,7 +47,7 @@ func New(ctx context.Context, config *Config) (*CFFT, error) {
 }
 
 func (app *CFFT) prepareKVS(ctx context.Context, create bool) error {
-	if app.config.KVS == nil {
+	if app.config == nil || app.config.KVS == nil {
 		return nil
 	}
 	name := app.config.KVS.Name

--- a/cfft.go
+++ b/cfft.go
@@ -34,7 +34,9 @@ func New(ctx context.Context, config *Config) (*CFFT, error) {
 		config: config,
 		envs:   map[string]string{},
 	}
-	awscfg, err := awsConfig.LoadDefaultConfig(ctx)
+
+	// CloudFront region is fixed to us-east-1
+	awscfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion("us-east-1"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load aws config, %w", err)
 	}

--- a/cli.go
+++ b/cli.go
@@ -57,6 +57,10 @@ func RunCLI(ctx context.Context, args []string) error {
 }
 
 func (app *CFFT) Dispatch(ctx context.Context, cmds []string, cli *CLI) error {
+	if err := app.prepareKVS(ctx, cli.Test.CreateIfMissing); err != nil {
+		return err
+	}
+
 	for k, v := range app.envs {
 		reset := localEnv(k, v)
 		defer reset()

--- a/cli.go
+++ b/cli.go
@@ -56,6 +56,11 @@ func RunCLI(ctx context.Context, args []string) error {
 }
 
 func (app *CFFT) Dispatch(ctx context.Context, cmd string, cli *CLI) error {
+	for k, v := range app.envs {
+		reset := localEnv(k, v)
+		defer reset()
+	}
+
 	switch cmd {
 	case "test":
 		return app.TestFunction(ctx, cli.Test)

--- a/cli.go
+++ b/cli.go
@@ -14,6 +14,7 @@ type CLI struct {
 	Init    InitCmd    `cmd:"" help:"initialize files"`
 	Diff    DiffCmd    `cmd:"" help:"diff function code"`
 	Publish PublishCmd `cmd:"" help:"publish function"`
+	KVS     KVSCmd     `cmd:"" help:"manage key-value store"`
 	Version VersionCmd `cmd:"" help:"show version"`
 
 	Config string `short:"c" long:"config" help:"config file" default:"cfft.yaml"`
@@ -35,14 +36,14 @@ func RunCLI(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	cmd := strings.Fields(kctx.Command())[0]
-	if cmd == "version" {
+	cmds := strings.Fields(kctx.Command())
+	if cmds[0] == "version" {
 		fmt.Println("cfft version", Version)
 		return nil
 	}
 
 	var config *Config
-	if cmd != "init" {
+	if cmds[0] != "init" {
 		config, err = LoadConfig(ctx, cli.Config)
 		if err != nil {
 			return err
@@ -52,16 +53,16 @@ func RunCLI(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	return app.Dispatch(ctx, cmd, &cli)
+	return app.Dispatch(ctx, cmds, &cli)
 }
 
-func (app *CFFT) Dispatch(ctx context.Context, cmd string, cli *CLI) error {
+func (app *CFFT) Dispatch(ctx context.Context, cmds []string, cli *CLI) error {
 	for k, v := range app.envs {
 		reset := localEnv(k, v)
 		defer reset()
 	}
 
-	switch cmd {
+	switch cmds[0] {
 	case "test":
 		return app.TestFunction(ctx, cli.Test)
 	case "init":
@@ -70,6 +71,8 @@ func (app *CFFT) Dispatch(ctx context.Context, cmd string, cli *CLI) error {
 		return app.DiffFunction(ctx, cli.Diff)
 	case "publish":
 		return app.PublishFunction(ctx, cli.Publish)
+	case "kvs":
+		return app.ManageKVS(ctx, cmds[1], cli.KVS)
 	case "version":
 		//
 	default:

--- a/diff.go
+++ b/diff.go
@@ -40,7 +40,10 @@ func (app *CFFT) DiffFunction(ctx context.Context, opt DiffCmd) error {
 		remote = aws.ToString(res.ETag)
 	}
 	local := app.config.Function
-	localCode := app.config.functionCode
+	localCode, err := app.config.FunctionCode()
+	if err != nil {
+		return fmt.Errorf("failed to read function code, %w", err)
+	}
 
 	edits := myers.ComputeEdits(span.URIFromPath(remote), string(remoteCode), string(localCode))
 	out := fmt.Sprint(gotextdiff.ToUnified(remote, local, string(remoteCode), edits))

--- a/examples/true-client-ip/cfft.yaml
+++ b/examples/true-client-ip/cfft.yaml
@@ -1,5 +1,7 @@
 name: "{{ env `NAME` `true-client-ip` }}"
 function: function.js
+kvs:
+  name: ipset
 testCases:
   - name: default
     event: event.json

--- a/examples/true-client-ip/function.js
+++ b/examples/true-client-ip/function.js
@@ -1,13 +1,12 @@
 import cf from 'cloudfront';
-const hostnames = {
-  '127.0.0.1': 'localhost',
-  '192.168.1.1': 'home',
-}
+
+const kvsId = "{{ must_env `KVS_ID` }}";
+const kvsHandle = cf.kvs(kvsId);
 
 async function handler(event) {
   const request = event.request;
   const clientIP = event.viewer.ip;
-  const hostname = hostnames[clientIP] || 'unknown';
+  const hostname = (await kvsHandle.exists(clientIP)) ? await kvsHandle.get(clientIP) : 'unknown';
 
   request.headers['true-client-ip'] = { value: clientIP };
   request.headers['x-hostname'] = { value: hostname };

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.32.5
+	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.1.5
 	github.com/fatih/color v1.12.0
 	github.com/goccy/go-yaml v1.11.2
 	github.com/google/go-jsonnet v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 h1:GrSw8s0Gs/5zZ0SX+gX4zQjRnRsM
 github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2/go.mod h1:6fQQgfuGmw8Al/3M2IgIllycxV7ZW7WCdVSqfBeUiCY=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.32.5 h1:synDXYpTr5FA80g8twNr49Dd7iAKnxerp93l/kNm/cQ=
 github.com/aws/aws-sdk-go-v2/service/cloudfront v1.32.5/go.mod h1:Dil6nVeCPyPc1gF5EeCrVUTtXexn80MpfqhgSp/Zb64=
+github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.1.5 h1:Kawulv7axsa/47vQzNpJnxA/Db1PLTbzs17FGjkvveg=
+github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.1.5/go.mod h1:6Jnl9lWGJQ1o94vjR1b3IhEta9bNq1E1uQClUL+n7jE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 h1:/b31bi3YVNlkzkBrm9LfpaKoaYZUxIAj4sHfOTmLfqw=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4/go.mod h1:2aGXHFmbInwgP9ZfpmdIfOELL79zhdNYNmReK8qDfdQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.9 h1:Nf2sHxjMJR8CSImIVCONRi4g0Su3J+TSTbS7G0pUeMU=

--- a/kvs.go
+++ b/kvs.go
@@ -1,0 +1,171 @@
+package cfft
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore"
+)
+
+type KVSCmd struct {
+	List   struct{}      `cmd:"" help:"list key values"`
+	Get    *KVSGetCmd    `cmd:"" help:"get value of key"`
+	Put    *KVSPutCmd    `cmd:"" help:"put value of key"`
+	Delete *KVSDeleteCmd `cmd:"" help:"delete key"`
+	Info   struct{}      `cmd:"" help:"show info of key value store"`
+
+	Output string `short:"o" help:"output format (json, text)" default:"json" enum:"json,text"`
+}
+
+type KVSGetCmd struct {
+	Key string `arg:"" help:"key name" required:""`
+}
+
+type KVSPutCmd struct {
+	Key   string `arg:"" help:"key name" required:""`
+	Value string `arg:"" help:"value" required:""`
+}
+
+type KVSDeleteCmd struct {
+	Key string `arg:"" help:"key name" required:""`
+}
+
+func (app *CFFT) ManageKVS(ctx context.Context, op string, opt KVSCmd) error {
+	switch op {
+	case "list":
+		return app.KVSList(ctx, opt)
+	case "get":
+		return app.KVSGet(ctx, opt)
+	case "put":
+		return app.KVSPut(ctx, opt)
+	case "delete":
+		return app.KVSDelete(ctx, opt)
+	case "info":
+		return app.KVSInfo(ctx, opt)
+	default:
+		return fmt.Errorf("unknown command %s", op)
+	}
+}
+
+func (app *CFFT) KVSList(ctx context.Context, opt KVSCmd) error {
+	p := cloudfrontkeyvaluestore.NewListKeysPaginator(app.cfkvs, &cloudfrontkeyvaluestore.ListKeysInput{
+		KvsARN:     aws.String(app.cfkvsArn),
+		MaxResults: aws.Int32(50),
+	})
+	buf := bufio.NewWriter(os.Stdout)
+	for p.HasMorePages() {
+		res, err := p.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list keys, %w", err)
+		}
+		for _, item := range res.Items {
+			s, err := formatKVSItem(&KVSItem{Key: aws.ToString(item.Key), Value: aws.ToString(item.Value)}, opt.Output)
+			if err != nil {
+				return fmt.Errorf("failed to format item, %w", err)
+			}
+			buf.WriteString(s)
+		}
+	}
+	return buf.Flush()
+}
+
+func (app *CFFT) KVSGet(ctx context.Context, opt KVSCmd) error {
+	res, err := app.cfkvs.GetKey(ctx, &cloudfrontkeyvaluestore.GetKeyInput{
+		KvsARN: aws.String(app.cfkvsArn),
+		Key:    aws.String(opt.Get.Key),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	s, err := formatKVSItem(&KVSItem{Key: aws.ToString(res.Key), Value: aws.ToString(res.Value)}, opt.Output)
+	if err != nil {
+		return fmt.Errorf("failed to format item, %w", err)
+	}
+	fmt.Fprint(os.Stdout, s)
+	return nil
+}
+
+func (app *CFFT) KVSPut(ctx context.Context, opt KVSCmd) error {
+	res, err := app.cfkvs.DescribeKeyValueStore(ctx, &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
+		KvsARN: aws.String(app.cfkvsArn),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	if _, err := app.cfkvs.PutKey(ctx, &cloudfrontkeyvaluestore.PutKeyInput{
+		KvsARN:  aws.String(app.cfkvsArn),
+		IfMatch: res.ETag,
+		Key:     aws.String(opt.Put.Key),
+		Value:   aws.String(opt.Put.Value),
+	}); err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	return nil
+}
+
+func (app *CFFT) KVSDelete(ctx context.Context, opt KVSCmd) error {
+	res, err := app.cfkvs.DescribeKeyValueStore(ctx, &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
+		KvsARN: aws.String(app.cfkvsArn),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	if _, err := app.cfkvs.DeleteKey(ctx, &cloudfrontkeyvaluestore.DeleteKeyInput{
+		KvsARN:  aws.String(app.cfkvsArn),
+		IfMatch: res.ETag,
+		Key:     aws.String(opt.Delete.Key),
+	}); err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	return nil
+}
+
+func (app *CFFT) KVSInfo(ctx context.Context, opt KVSCmd) error {
+	res, err := app.cfkvs.DescribeKeyValueStore(ctx, &cloudfrontkeyvaluestore.DescribeKeyValueStoreInput{
+		KvsARN: aws.String(app.cfkvsArn),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get key, %w", err)
+	}
+	switch opt.Output {
+	case "json":
+		b, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal kvs, %w", err)
+		}
+		fmt.Fprintln(os.Stdout, string(b))
+	case "text":
+		fmt.Fprintf(os.Stdout, "KvsARN\t%s\n", aws.ToString(res.KvsARN))
+		fmt.Fprintf(os.Stdout, "ETag\t%s\n", aws.ToString(res.ETag))
+		fmt.Fprintf(os.Stdout, "ItemCount\t%d\n", aws.ToInt32(res.ItemCount))
+		fmt.Fprintf(os.Stdout, "TotalSizeInBytes\t%d\n", aws.ToInt64(res.TotalSizeInBytes))
+		fmt.Fprintf(os.Stdout, "Created\t%s\n", res.Created.Format(time.RFC3339))
+		fmt.Fprintf(os.Stdout, "LastModified\t%s\n", res.LastModified.Format(time.RFC3339))
+	}
+	return nil
+}
+
+type KVSItem struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func formatKVSItem(item *KVSItem, format string) (string, error) {
+	switch format {
+	case "json":
+		b, err := json.Marshal(item)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal item, %w", err)
+		}
+		return string(b) + "\n", nil
+	case "text":
+		return fmt.Sprintf("%s\t%s\n", item.Key, item.Value), nil
+	default:
+		return "", fmt.Errorf("unknown format %s", format)
+	}
+}


### PR DESCRIPTION
This PR enables the management of CloudFront KeyValueStores.

```yaml
name: resolve-hostname
function: function.js
kvs:
  name: hostnames
```

In cfft.yaml, a `kvs` element specifies the KVS name associated with the function.

In `function.js`, the ID of the KVS is set to `KVS_ID` environment variable.

```js
import cf from 'cloudfront';

const kvsId = "{{ must_env `KVS_ID` }}";
const kvsHandle = cf.kvs(kvsId);

async function handler(event) {
  const request = event.request;
  const clientIP = event.viewer.ip;
  const hostname = (await kvsHandle.exists(clientIP)) ? await kvsHandle.get(clientIP) : 'unknown';

  request.headers['true-client-ip'] = { value: clientIP };
  request.headers['x-hostname'] = { value: hostname };
  return request;
}
```

`cfft kvs` sub-command can manage the key-value pairs in the KVS.

```console
$ cfft kvs --help
Usage: cfft kvs <command>

manage key-value store

Flags:
  -h, --help                  Show context-sensitive help.
  -c, --config="cfft.yaml"    config file

  -o, --output="json"         output format (json, text)

Commands:
  kvs list
    list key values

  kvs get <key>
    get value of key

  kvs put <key> <value>
    put value of key

  kvs delete <key>
    delete key

  kvs info
    show info of key value store
```