### PR TITLE
request and response can parse a HTTP text object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,90 @@ cfft supports the following file extensions.
 - .yaml
 - .yml
 
+### HTTP text format for Request and Response objects
+
+cfft supports an HTTP text format for Request and Response objects.
+
+The following example is the HTTP text format of the Request object.
+
+```
+GET /index.html HTTP/1.1
+Host: example.com
+```
+
+The request object is converted to the following JSON object.
+
+```json
+{
+  "method": "GET",
+  "uri": "/index.html",
+  "headers": {
+    "host": {
+      "value": "example.com"
+    }
+  }
+}
+```
+
+The following example is the HTTP text format of the Response object.
+
+```
+HTTP/1.1 302 Found
+Location: https://example.com/
+```
+
+The response object is converted to the following JSON object.
+
+```json
+{
+  "statusCode": 302,
+  "statusDescription": "Found",
+  "headers": {
+    "location": {
+      "value": "https://example.com/"
+    }
+  }
+}
+```
+
+For use of the text format, I recommend using YAML or Jsonnet format for the event and expect files instead of plain JSON. YAML and Jsonnet support multiline strings.
+
+```yaml
+# event.yaml
+---
+version: "1.0"
+context:
+  eventType: viewer-response
+viewer:
+  ip: 1.2.3.4
+request: |
+  GET /index.html HTTP/1.1
+  Host: example.com
+response: |
+  HTTP/1.1 302 Found
+  Location: https://example.com/
+```
+
+```jsonnet
+{
+  version: '1.0',
+  context: {
+    eventType: 'viewer-response',
+  },
+  viewer: {
+    ip: '1.2.3.4',
+  },
+  request: |||
+    GET /index.html HTTP/1.1
+    Host: example.com
+  |||,
+  response: |||
+    HTTP/1.1 302 Found
+    Location: https://example.com/
+  |||,
+}
+```
+
 ### Use CloudFront KeyValueStore
 
 cfft supports [CloudFront KeyVakueStore](https://docs.aws.amazon.com/ja_jp/AmazonCloudFront/latest/DeveloperGuide/kvs-with-functions.html).

--- a/cfft.go
+++ b/cfft.go
@@ -256,7 +256,7 @@ func (app *CFFT) associateKVS(ctx context.Context, fc *types.FunctionConfig) (bo
 
 func (app *CFFT) runTestCase(ctx context.Context, name, etag string, c *TestCase) error {
 	log.Printf("[info] testing function %s with case %s...", name, c.Identifier())
-	//log.Printf("[debug] event: %s", string(c.event))
+	log.Printf("[debug] event: %s", string(c.EventBytes()))
 	res, err := app.cloudfront.TestFunction(ctx, &cloudfront.TestFunctionInput{
 		Name:        aws.String(name),
 		IfMatch:     aws.String(etag),

--- a/cfft.go
+++ b/cfft.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	"github.com/aereal/jsondiff"
@@ -262,36 +261,33 @@ func (app *CFFT) runTestCase(ctx context.Context, name, etag string, c *TestCase
 		Name:        aws.String(name),
 		IfMatch:     aws.String(etag),
 		Stage:       Stage,
-		EventObject: c.event,
+		EventObject: c.EventBytes(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to test function, %w", err)
 	}
 	var failed bool
 	if errMsg := aws.ToString(res.TestResult.FunctionErrorMessage); errMsg != "" {
-		log.Printf("[error] %s", errMsg)
+		log.Printf("[error][%s] %s", c.Identifier(), errMsg)
 		failed = true
 	}
-	log.Printf("[info] ComputeUtilization:%s", aws.ToString(res.TestResult.ComputeUtilization))
+	log.Printf("[info][%s] ComputeUtilization:%s", c.Identifier(), aws.ToString(res.TestResult.ComputeUtilization))
 	for _, l := range res.TestResult.FunctionExecutionLogs {
 		log.Println(l)
 	}
-	var out any
-	if err := json.Unmarshal([]byte(*res.TestResult.FunctionOutput), &out); err != nil {
-		return fmt.Errorf("failed to parse function output, %w", err)
-	}
-	prettyOutput, _ := json.MarshalIndent(out, "", "  ")
-	prettyOutput = append(prettyOutput, '\n')
-	os.Stdout.Write(prettyOutput)
+	out := *res.TestResult.FunctionOutput
 	if failed {
+		log.Printf("[info][%s] function output: %s", c.Identifier(), out)
 		return errors.New("test failed")
+	} else {
+		log.Printf("[debug][%s] function output: %s", c.Identifier(), out)
 	}
 	if c.expect == nil {
 		return nil
 	}
 
-	var rhs any
-	if err := json.Unmarshal([]byte(*res.TestResult.FunctionOutput), &rhs); err != nil {
+	var result CFFExpect
+	if err := json.Unmarshal([]byte(*res.TestResult.FunctionOutput), &result); err != nil {
 		return fmt.Errorf("failed to parse function output, %w", err)
 	}
 	var options []jsondiff.Option
@@ -300,7 +296,7 @@ func (app *CFFT) runTestCase(ctx context.Context, name, etag string, c *TestCase
 	}
 	diff, err := jsondiff.Diff(
 		&jsondiff.Input{Name: "expect", X: c.expect},
-		&jsondiff.Input{Name: "actual", X: rhs},
+		&jsondiff.Input{Name: "actual", X: result},
 		options...,
 	)
 	if err != nil {
@@ -310,7 +306,7 @@ func (app *CFFT) runTestCase(ctx context.Context, name, etag string, c *TestCase
 		fmt.Print(coloredDiff(diff))
 		return fmt.Errorf("expect and actual are not equal")
 	} else {
-		log.Println("[info] expect and actual are equal")
+		log.Printf("[info][%s] OK", c.Identifier())
 	}
 	return nil
 }

--- a/examples/add-cache-control/cfft.yaml
+++ b/examples/add-cache-control/cfft.yaml
@@ -5,3 +5,6 @@ testCases:
   - name: add-cache-control
     event: event.json
     expect: expect.json
+  - name: add-cache-control-text
+    event: event.yaml
+    expect: expect.yaml

--- a/examples/add-cache-control/event.yaml
+++ b/examples/add-cache-control/event.yaml
@@ -1,0 +1,11 @@
+---
+version: "1.0"
+context:
+  eventType: viewer-response
+viewer:
+  ip: 1.2.3.4
+request: |
+  GET /index.html HTTP/1.1
+  Host: example.com
+response: |
+  HTTP/1.1 200 OK

--- a/examples/add-cache-control/expect.yaml
+++ b/examples/add-cache-control/expect.yaml
@@ -1,0 +1,4 @@
+---
+response: |
+  HTTP/1.1 200 OK
+  Cache-Control: public, max-age=6307200

--- a/examples/add-cache-control/function.js
+++ b/examples/add-cache-control/function.js
@@ -3,7 +3,7 @@ async function handler(event) {
   const headers = response.headers;
 
   // Set the cache-control header
-  headers['cache-control'] = { value: 'public, max-age=63072000' };
+  headers['cache-control'] = { value: 'public, max-age=6307200' };
   console.log('[on the edge] Cache-Control header set.');
 
   // Return response to viewers

--- a/go.mod
+++ b/go.mod
@@ -31,10 +31,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.6 // indirect
 	github.com/aws/smithy-go v1.19.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/samber/lo v1.39.0 // indirect
+	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7a
 github.com/goccy/go-yaml v1.11.2 h1:joq77SxuyIs9zzxEjgyLBugMQ9NEgTWxXfz2wVqwAaQ=
 github.com/goccy/go-yaml v1.11.2/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-jsonnet v0.20.0 h1:WG4TTSARuV7bSm4PMB4ohjxe33IHT5WVTrJSU33uT4g=
 github.com/google/go-jsonnet v0.20.0/go.mod h1:VbgWF9JX7ztlv770x/TolZNGGFfiHEVx9G6ca2eUmeA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -68,11 +70,15 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/shogo82148/go-retry v1.2.0 h1:A/LFdbZKJ+tsT1gF4OrzM4P10FGK7VUExpb07/U03aE=
 github.com/shogo82148/go-retry v1.2.0/go.mod h1:wttfgfwCMQvNqv4kOpqIvDDJeSmwU+AEIpUyG+5Ca6M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl46qQakyfqfWo4jgfaEM=
+golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/testcase_test.go
+++ b/testcase_test.go
@@ -24,3 +24,21 @@ func TestSetup(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupText(t *testing.T) {
+	ctx := context.Background()
+
+	for _, ext := range []string{".jsonnet"} {
+		t.Run(ext, func(t *testing.T) {
+			testCase := &cfft.TestCase{
+				Event:  "testdata/text_event" + ext,
+				Expect: "testdata/expect" + ext,
+				Ignore: ".foo",
+			}
+			err := testCase.Setup(ctx, cfft.ReadFile)
+			if err != nil {
+				t.Errorf("Setup returned an error: %v", err)
+			}
+		})
+	}
+}

--- a/testdata/text_event.jsonnet
+++ b/testdata/text_event.jsonnet
@@ -1,0 +1,24 @@
+{
+  version: '1.0',
+  context: {
+    eventType: 'viewer-response',
+  },
+  viewer: {
+    ip: '1.2.3.4',
+  },
+  request: |||
+    GET /index.html HTTP/1.1
+    Host: example.com
+    User-Agent: Mozilla/5.0
+    Cookie: foo=bar, bar=baz
+    Cookie: bar=xxx
+  |||,
+  response: |||
+    HTTP/1.1 200 OK
+    Content-Type: text/html
+    Content-Length: 13
+    Set-Cookie: foo=bar; Secure; Path=/; Domain=example.com
+
+    Hello World!
+  |||,
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,498 @@
+package cfft
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/samber/lo"
+)
+
+type UtilCmd struct {
+	ParseRequest  ParseRequestCmd  `cmd:"" help:"parse HTTP request text from STDIN"`
+	ParseResponse ParseResponseCmd `cmd:"" help:"parse HTTP response text from STDIN"`
+}
+
+type ParseRequestCmd struct{}
+
+type ParseResponseCmd struct{}
+
+func (app *CFFT) RunUtil(ctx context.Context, op string, opt UtilCmd) error {
+	switch op {
+	case "parse-request":
+		return app.UtilParseRequest(ctx, opt.ParseRequest)
+	case "parse-response":
+		return app.UtilParseResponse(ctx, opt.ParseResponse)
+	default:
+		return fmt.Errorf("unknown command %s", op)
+	}
+}
+
+func (app *CFFT) UtilParseRequest(ctx context.Context, opt ParseRequestCmd) error {
+	text, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read request from STDIN, %w", err)
+	}
+	req, err := ParseRequest(string(text))
+	if err != nil {
+		return fmt.Errorf("failed to parse request, %w", err)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(req)
+}
+
+func (app *CFFT) UtilParseResponse(ctx context.Context, opt ParseResponseCmd) error {
+	text, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return fmt.Errorf("failed to read response from STDIN, %w", err)
+	}
+	resp, err := ParseResponse(string(text))
+	if err != nil {
+		return fmt.Errorf("failed to parse response, %w", err)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+type CFFEvent struct {
+	Version  string       `json:"version"`
+	Context  *CFFContext  `json:"context"`
+	Viewer   *CFFViewer   `json:"viewer"`
+	Request  *CFFRequest  `json:"request"`
+	Response *CFFResponse `json:"response"`
+}
+
+func (r *CFFRequest) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		r = nil
+		return nil
+	}
+	switch b[0] {
+	case '"':
+		// request is string
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		_r, err := ParseRequest(s)
+		if err != nil {
+			return err
+		}
+		*r = _r
+	case '{':
+		// request is object
+		var x cffrequest
+		if err := json.Unmarshal(b, &x); err != nil {
+			return err
+		}
+		*r = (CFFRequest)(x)
+	default:
+		return fmt.Errorf("invalid request object: %s", string(b))
+	}
+	return nil
+}
+
+func (e *CFFEvent) Bytes() []byte {
+	b, _ := json.Marshal(e)
+	return b
+}
+
+/*
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html#functions-event-structure-context
+distributionDomainName
+The CloudFront domain name (for example, d111111abcdef8.cloudfront.net) of the distribution that's associated with the event.
+
+distributionId
+The ID of the distribution (for example, EDFDVBD6EXAMPLE) that's associated with the event.
+
+eventType
+The event type, either viewer-request or viewer-response.
+
+requestId
+A string that uniquely identifies a CloudFront request (and its associated response).
+*/
+type CFFContext struct {
+	DistributionDomainName string `json:"distributionDomainName"`
+	DistributionId         string `json:"distributionId"`
+	EventType              string `json:"eventType"`
+	RequestId              string `json:"requestId"`
+}
+
+/*
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html#functions-event-structure-viewer
+
+The viewer object contains an ip field whose value is the IP address of the viewer (client) that sent the request. If the viewer request came through an HTTP proxy or a load balancer, the value is the IP address of the proxy or load balancer.
+*/
+type CFFViewer struct {
+	IP string `json:"ip"`
+}
+
+/*
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html#functions-event-structure-request
+
+The request object contains the following fields:
+
+method
+The HTTP method of the request. If your function code returns a request, it cannot modify this field. This is the only read-only field in the request object.
+
+uri
+The relative path of the requested object. If your function modifies the uri value, note the following:
+The new uri value must begin with a forward slash (/).
+When a function changes the uri value, it changes the object that the viewer is requesting.
+When a function changes the uri value, it doesn't change the cache behavior for the request or the origin that an origin request is sent to.
+
+querystring
+An object that represents the query string in the request. If the request doesn't include a query string, the request object still includes an empty querystring object.
+The querystring object contains one field for each query string parameter in the request.
+
+headers
+An object that represents the HTTP headers in the request. If the request contains any Cookie headers, those headers are not part of the headers object. Cookies are represented separately in the cookies object.
+The headers object contains one field for each header in the request. Header names are converted to lowercase in the event object, and header names must be lowercase when they're added by your function code. When CloudFront Functions converts the event object back into an HTTP request, the first letter of each word in header names is capitalized. Words are separated by a hyphen (-). For example, if your function code adds a header named example-header-name, CloudFront converts this to Example-Header-Name in the HTTP request.
+
+cookies
+An object that represents the cookies in the request (Cookie headers).
+The cookies object contains one field for each cookie in the request.
+*/
+
+type CFFValue struct {
+	Value      string     `json:"value"`
+	MultiValue []CFFValue `json:"multiValue,omitempty"`
+}
+
+type CFFCookieValue struct {
+	Value      string           `json:"value"`
+	Attributes string           `json:"attributes,omitempty"`
+	MultiValue []CFFCookieValue `json:"multiValue,omitempty"`
+}
+
+type cffrequest CFFRequest
+
+type CFFRequest struct {
+	Method      string                    `json:"method"`
+	URI         string                    `json:"uri"`
+	QueryString map[string]CFFValue       `json:"querystring,omitempty"`
+	Headers     map[string]CFFValue       `json:"headers,omitempty"`
+	Cookies     map[string]CFFCookieValue `json:"cookies,omitempty"`
+}
+
+/*
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-event-structure.html#functions-event-structure-response
+The response object contains the following fields:
+
+statusCode
+The HTTP status code of the response. This value is an integer, not a string.
+Your function can generate or modify the statusCode.
+
+statusDescription
+The HTTP status description of the response. If your function code generates a response, this field is optional.
+
+headers
+An object that represents the HTTP headers in the response. If the response contains any Set-Cookie headers, those headers are not part of the headers object. Cookies are represented separately in the cookies object.
+The headers object contains one field for each header in the response. Header names are converted to lowercase in the event object, and header names must be lowercase when they're added by your function code. When CloudFront Functions converts the event object back into an HTTP response, the first letter of each word in header names is capitalized. Words are separated by a hyphen (-). For example, if your function code adds a header named example-header-name, CloudFront converts this to Example-Header-Name in the HTTP response.
+
+cookies
+An object that represents the cookies in the response (Set-Cookie headers).
+The cookies object contains one field for each cookie in the response.
+
+body
+Adding the body field is optional, and it will not be present in the response object unless you specify it in your function. Your function does not have access to the original body returned by the CloudFront cache or origin. If you don't specify the body field in your viewer response function, the original body returned by the CloudFront cache or origin is returned to viewer.
+If you want CloudFront to return a custom body to the viewer, specify the body content in the data field, and the body encoding in the encoding field. You can specify the encoding as plain text ("encoding": "text") or as Base64-encoded content ("encoding": "base64").
+As a shortcut, you can also specify the body content directly in the body field ("body": "<specify the body content here>"). When you do this, omit the data and encoding fields. CloudFront treats the body as plain text in this case.
+
+encoding
+The encoding for the body content (data field). The only valid encodings are text and base64.
+If you specify encoding as base64 but the body is not valid base64, CloudFront returns an error.
+data
+The body content.
+*/
+
+type cffresponse CFFResponse
+
+type CFFResponse struct {
+	StatusCode        int                       `json:"statusCode"`
+	StatusDescription string                    `json:"statusDescription,omitempty"`
+	Headers           map[string]CFFValue       `json:"headers,omitempty"`
+	Cookies           map[string]CFFCookieValue `json:"cookies,omitempty"`
+	Body              *CFFBody                  `json:"body,omitempty"`
+}
+
+func (r *CFFResponse) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		r = nil
+		return nil
+	}
+	switch b[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		_r, err := ParseResponse(s)
+		if err != nil {
+			return err
+		}
+		*r = _r
+	case '{':
+		// response is object
+		var x cffresponse
+		if err := json.Unmarshal(b, &x); err != nil {
+			return err
+		}
+		*r = (CFFResponse)(x)
+	default:
+		return fmt.Errorf("invalid response object: %s", string(b))
+	}
+	return nil
+}
+
+type CFFBody struct {
+	Encoding string `json:"encoding"`
+	Data     string `json:"data"`
+}
+
+func ParseRequest(text string) (CFFRequest, error) {
+	req, err := textToHTTPRequest(text)
+	if err != nil {
+		return CFFRequest{}, fmt.Errorf("failed to parse request, %w", err)
+	}
+	r := CFFRequest{
+		Method:      req.Method,
+		URI:         req.URL.String(),
+		Headers:     map[string]CFFValue{},
+		Cookies:     map[string]CFFCookieValue{},
+		QueryString: map[string]CFFValue{},
+	}
+	// fill headers
+	for k, v := range req.Header {
+		k := strings.ToLower(k)
+		if k == "cookie" {
+			continue
+		}
+		if len(v) == 1 {
+			r.Headers[k] = CFFValue{Value: v[0]}
+		} else {
+			r.Headers[k] = CFFValue{
+				Value: v[0],
+				MultiValue: lo.Map(v, func(s string, _ int) CFFValue {
+					return CFFValue{Value: s}
+				}),
+			}
+		}
+	}
+	// fill cookies
+	for _, c := range req.Cookies() {
+		if cv, ok := r.Cookies[c.Name]; !ok {
+			r.Cookies[c.Name] = CFFCookieValue{
+				Value:      c.Value,
+				MultiValue: []CFFCookieValue{{Value: c.Value}},
+			}
+		} else {
+			// multi-value
+			cv.MultiValue = append(cv.MultiValue, CFFCookieValue{
+				Value: c.Value,
+			})
+			r.Cookies[c.Name] = cv
+		}
+	}
+	// remove multi-value if not needed
+	for k, v := range r.Cookies {
+		if len(v.MultiValue) <= 1 {
+			v.MultiValue = nil
+			r.Cookies[k] = v
+		}
+	}
+
+	// fill query string
+	for k, v := range req.URL.Query() {
+		if len(v) == 1 {
+			r.QueryString[k] = CFFValue{Value: v[0]}
+		} else {
+			r.QueryString[k] = CFFValue{
+				Value: v[0],
+				MultiValue: lo.Map(v, func(s string, _ int) CFFValue {
+					return CFFValue{Value: s}
+				}),
+			}
+		}
+	}
+
+	return r, nil
+}
+
+func ParseResponse(text string) (CFFResponse, error) {
+	resp, err := textToHTTPResponse(text)
+	if err != nil {
+		return CFFResponse{}, fmt.Errorf("failed to parse response, %w", err)
+	}
+	r := CFFResponse{
+		StatusCode:        resp.StatusCode,
+		StatusDescription: resp.Status,
+		Headers:           map[string]CFFValue{},
+		Cookies:           map[string]CFFCookieValue{},
+		Body:              nil,
+	}
+	// fill headers
+	for k, v := range resp.Header {
+		k := strings.ToLower(k)
+		if k == "set-cookie" {
+			continue
+		}
+		if len(v) == 1 {
+			r.Headers[k] = CFFValue{Value: v[0]}
+		} else {
+			r.Headers[k] = CFFValue{
+				Value: v[0],
+				MultiValue: lo.Map(v, func(s string, _ int) CFFValue {
+					return CFFValue{Value: s}
+				}),
+			}
+		}
+	}
+	// fill cookies
+	for _, c := range resp.Cookies() {
+		if cv, ok := r.Cookies[c.Name]; !ok {
+			r.Cookies[c.Name] = CFFCookieValue{
+				Value:      c.Value,
+				Attributes: strings.TrimPrefix(c.String(), c.Name+"="+c.Value+"; "),
+			}
+		} else {
+			// multi-value
+			cv.MultiValue = append(cv.MultiValue, CFFCookieValue{
+				Value:      c.Value,
+				Attributes: strings.TrimPrefix(c.String(), c.Name+"="+c.Value+"; "),
+			})
+			r.Cookies[c.Name] = cv
+		}
+	}
+
+	// fill body
+	if resp.Body != nil {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return CFFResponse{}, fmt.Errorf("failed to read body, %w", err)
+		}
+		r.Body = &CFFBody{
+			Encoding: "text",
+			Data:     string(body),
+		}
+	}
+	return r, nil
+}
+
+func textToHTTPRequest(text string) (*http.Request, error) {
+	buf := bytes.NewBufferString(text)
+	reader := bufio.NewReader(buf)
+
+	requestLine, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(strings.TrimSpace(requestLine), " ")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid request line")
+	}
+
+	req, err := http.NewRequest(parts[0], parts[1], nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Proto = parts[2]
+
+	// read headers
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			break // End of header
+		}
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid header line")
+		}
+		req.Header.Add(parts[0], parts[1])
+	}
+
+	// read body
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	return req, nil
+}
+
+func textToHTTPResponse(text string) (*http.Response, error) {
+	buf := bytes.NewBufferString(text)
+	reader := bufio.NewReader(buf)
+
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+
+	// parse status line
+	parts := strings.SplitN(strings.TrimSpace(statusLine), " ", 3)
+	switch len(parts) {
+	case 0, 1:
+		return nil, fmt.Errorf("invalid status line")
+	case 2:
+		parts = append(parts, "") // status description is optional
+	}
+
+	statusCode, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid status code")
+	}
+
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Status:     strings.TrimSpace(parts[2]),
+		Header:     make(http.Header),
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				// When reached the EOF while reading header, body should be nil.
+				resp.Body = nil
+				return resp, nil
+			}
+			return nil, err
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			break // End of header
+		}
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid header line")
+		}
+		resp.Header.Add(parts[0], parts[1])
+	}
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return resp, nil
+}

--- a/util.go
+++ b/util.go
@@ -64,11 +64,11 @@ func (app *CFFT) UtilParseResponse(ctx context.Context, opt ParseResponseCmd) er
 }
 
 type CFFEvent struct {
-	Version  string       `json:"version"`
-	Context  *CFFContext  `json:"context"`
-	Viewer   *CFFViewer   `json:"viewer"`
-	Request  *CFFRequest  `json:"request"`
-	Response *CFFResponse `json:"response"`
+	Version  string       `json:"version,omitempty"`
+	Context  *CFFContext  `json:"context,omitempty"`
+	Viewer   *CFFViewer   `json:"viewer,omitempty"`
+	Request  *CFFRequest  `json:"request,omitempty"`
+	Response *CFFResponse `json:"response,omitempty"`
 }
 
 func (r *CFFRequest) UnmarshalJSON(b []byte) error {
@@ -121,10 +121,10 @@ requestId
 A string that uniquely identifies a CloudFront request (and its associated response).
 */
 type CFFContext struct {
-	DistributionDomainName string `json:"distributionDomainName"`
-	DistributionId         string `json:"distributionId"`
-	EventType              string `json:"eventType"`
-	RequestId              string `json:"requestId"`
+	DistributionDomainName string `json:"distributionDomainName,omitempty"`
+	DistributionId         string `json:"distributionId,omitempty"`
+	EventType              string `json:"eventType,omitempty"`
+	RequestId              string `json:"requestId,omitempty"`
 }
 
 /*
@@ -218,7 +218,7 @@ The body content.
 type cffresponse CFFResponse
 
 type CFFResponse struct {
-	StatusCode        int                       `json:"statusCode"`
+	StatusCode        int                       `json:"statusCode,omitempty"`
 	StatusDescription string                    `json:"statusDescription,omitempty"`
 	Headers           map[string]CFFValue       `json:"headers,omitempty"`
 	Cookies           map[string]CFFCookieValue `json:"cookies,omitempty"`

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,128 @@
+package cfft_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/fujiwara/cfft"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTextCFFRequest(t *testing.T) {
+	parsedRequest, err := cfft.ParseRequest(`GET /?foo=bar&foo=baz&bar=1 HTTP/1.1
+Host: example.com
+User-Agent: curl/7.64.1
+Accept: */*
+X-Forwarded-For: 127.0.0.1
+X-Forwarded-For: 192.168.1.1
+Cookie: foo=bar; baz=qux
+Cookie: baz=quux
+
+`)
+	if err != nil {
+		t.Errorf("ParseRequest returned an error: %v", err)
+	}
+	expect := `{
+		"method": "GET",
+		"uri": "/?foo=bar&foo=baz&bar=1",
+		"headers": {
+			"accept": {"value": "*/*"},
+			"x-forwarded-for": {
+				"value": "127.0.0.1",
+				"multiValue": [{"value": "127.0.0.1"}, {"value": "192.168.1.1"}]
+			},
+			"host": {"value": "example.com"},
+			"user-agent": {"value": "curl/7.64.1"}
+		},
+		"querystring": {
+			"foo": {"value": "bar", "multiValue": [{"value": "bar"}, {"value": "baz"}]},
+			"bar": {"value": "1"}
+		},
+		"cookies": {
+			"foo": {"value": "bar"},
+			"baz": {"value": "qux", "multiValue": [{"value": "qux"}, {"value": "quux"}]}
+		}
+	}`
+	var expectRequest cfft.CFFRequest
+	if err := json.Unmarshal([]byte(expect), &expectRequest); err != nil {
+		t.Fatalf("failed to parse expect as CFFRequest: %v", err)
+	}
+	if d := cmp.Diff(parsedRequest, expectRequest); d != "" {
+		t.Errorf("parsedRequest differs from expect: %s", d)
+	}
+}
+
+func TestCFFTextToResponse(t *testing.T) {
+	parsedResponse, err := cfft.ParseResponse(`HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+Content-Length: 13
+X-Foo: aaa
+X-Foo: bbb
+Set-Cookie: foo=bar; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Max-Age=86400; HttpOnly; Secure
+Set-Cookie: baz=qux; Path=/; Domain=example.com;
+
+Hello, World!`)
+	if err != nil {
+		t.Errorf("ParseResponse returned an error: %v", err)
+	}
+	expect := `{
+		"statusCode": 200,
+		"statusDescription": "OK",
+		"headers": {
+			"content-type": {"value": "text/plain; charset=utf-8"},
+			"content-length": {"value": "13"},
+			"x-foo": {
+				"value": "aaa",
+				"multiValue": [{"value": "aaa"}, {"value": "bbb"}]
+			}
+		},
+		"cookies": {
+			"foo": {
+				"value": "bar",
+				"attributes": "Expires=Wed, 13 Jan 2021 22:23:01 GMT; Max-Age=86400; HttpOnly; Secure"
+			},
+			"baz": {
+				"value": "qux",
+				"attributes": "Path=/; Domain=example.com"
+			}
+		},
+		"body": {
+			"encoding": "text",
+			"data": "Hello, World!"
+		}
+	}`
+	var expectResponse cfft.CFFResponse
+	if err := json.Unmarshal([]byte(expect), &expectResponse); err != nil {
+		t.Fatalf("failed to parse expect as CFFResponse: %v", err)
+	}
+	if diff := cmp.Diff(parsedResponse, expectResponse); diff != "" {
+		t.Errorf("parsedResponse differs from expect: %s", diff)
+	}
+}
+
+func TestCFFTextToResponseWitoutBody(t *testing.T) {
+	parsedResponse, err := cfft.ParseResponse(`HTTP/1.1 302 Found
+Location: https://example.com/
+`)
+	if err != nil {
+		t.Errorf("ParseResponse returned an error: %v", err)
+	}
+	expect := `{
+		"statusCode": 302,
+		"statusDescription": "Found",
+		"cookies": {},
+		"headers": {
+			"location": {"value": "https://example.com/"}
+		}
+	}`
+	var expectResponse cfft.CFFResponse
+	if err := json.Unmarshal([]byte(expect), &expectResponse); err != nil {
+		t.Fatalf("failed to parse expect as CFFResponse: %v", err)
+	}
+	if diff := cmp.Diff(parsedResponse, expectResponse); diff != "" {
+		t.Errorf("parsedResponse differs from expect: %s", diff)
+	}
+	if parsedResponse.Body != nil {
+		t.Errorf("parsedResponse.Body should be nil")
+	}
+}


### PR DESCRIPTION
### HTTP text format for Request and Response objects

cfft supports an HTTP text format for Request and Response objects.

The following example is the HTTP text format of the Request object.

```
GET /index.html HTTP/1.1
Host: example.com
```

The request object is converted to the following JSON object.

```json
{
  "method": "GET",
  "uri": "/index.html",
  "headers": {
    "host": {
      "value": "example.com"
    }
  }
}
```

The following example is the HTTP text format of the Response object.

```
HTTP/1.1 302 Found
Location: https://example.com/
```

The response object is converted to the following JSON object.

```json
{
  "statusCode": 302,
  "statusDescription": "Found",
  "headers": {
    "location": {
      "value": "https://example.com/"
    }
  }
}
```

For use of the text format, I recommend using YAML or Jsonnet format for the event and expect files instead of plain JSON. YAML and Jsonnet support multiline strings.

```yaml
# event.yaml
---
version: "1.0"
context:
  eventType: viewer-response
viewer:
  ip: 1.2.3.4
request: |
  GET /index.html HTTP/1.1
  Host: example.com
response: |
  HTTP/1.1 302 Found
  Location: https://example.com/
```

```jsonnet
{
  version: '1.0',
  context: {
    eventType: 'viewer-response',
  },
  viewer: {
    ip: '1.2.3.4',
  },
  request: |||
    GET /index.html HTTP/1.1
    Host: example.com
  |||,
  response: |||
    HTTP/1.1 302 Found
    Location: https://example.com/
  |||,
}
```
