### PR TITLE
support runtime-1.0

### DIFF
--- a/cfft.go
+++ b/cfft.go
@@ -25,6 +25,8 @@ var Version = "dev"
 
 var logLevel = new(slog.LevelVar)
 
+const DefaultRuntime = types.FunctionRuntimeCloudfrontJs20
+
 type CFFT struct {
 	config     *Config
 	cloudfront *cloudfront.Client
@@ -169,7 +171,7 @@ func (app *CFFT) createFunction(ctx context.Context, name string, code []byte) (
 		FunctionCode: code,
 		FunctionConfig: &types.FunctionConfig{
 			Comment:                   aws.String(app.config.Comment),
-			Runtime:                   types.FunctionRuntimeCloudfrontJs20,
+			Runtime:                   app.config.Runtime,
 			KeyValueStoreAssociations: kvsassociation,
 		},
 	})

--- a/tfdata.go
+++ b/tfdata.go
@@ -29,7 +29,7 @@ func (app *CFFT) RunTFData(ctx context.Context, opt *TFDataCmd) error {
 		Name:    app.config.Name,
 		Code:    string(localCode),
 		Comment: app.config.Comment,
-		Runtime: types.FunctionRuntimeCloudfrontJs20,
+		Runtime: app.config.Runtime,
 		KVSArn:  app.cfkvsArn,
 	}
 	enc := json.NewEncoder(os.Stdout)


### PR DESCRIPTION
The Default runtime is 2.0, but `cfft init` applies the runtime to the created config file.