### PR TITLE
Colored logging.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 )
 
 type CLI struct {
@@ -74,14 +75,16 @@ func RunCLI(ctx context.Context, args []string) error {
 		fmt.Println("cfft version", Version)
 		return nil
 	}
-	opt := &slog.HandlerOptions{
-		Level: logLevel,
+	opt := &HandlerOptions{}
+	opt.Level = logLevel
+	if isatty.IsTerminal(os.Stderr.Fd()) {
+		opt.Color = true
 	}
 	switch cli.LogFormat {
 	case "text":
 		slog.SetDefault(slog.New(NewLogHandler(os.Stderr, opt)))
 	case "json":
-		slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, opt)))
+		slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &opt.HandlerOptions)))
 	default:
 		return fmt.Errorf("invalid log format %s", cli.LogFormat)
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/itchyny/gojq v0.12.14
 	github.com/kayac/go-config v0.7.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/samber/lo v1.39.0
 	github.com/shogo82148/go-retry v1.2.0
@@ -38,7 +39,6 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/sloghandler.go
+++ b/sloghandler.go
@@ -40,13 +40,17 @@ func (h *logHandler) FprintfFunc(level slog.Level) func(io.Writer, string, ...in
 	if h.opts.Color {
 		switch level {
 		case slog.LevelWarn:
-			return color.New(color.FgYellow).FprintfFunc()
+			return warnColoredFprintfFunc
 		case slog.LevelError:
-			return color.New(color.FgRed).FprintfFunc()
+			return errorColoredFprintfFunc
 		}
 	}
 	return defaultFprintfFunc
 }
+
+var warnColoredFprintfFunc = color.New(color.FgYellow).FprintfFunc()
+
+var errorColoredFprintfFunc = color.New(color.FgRed).FprintfFunc()
 
 var defaultFprintfFunc = func(w io.Writer, format string, args ...interface{}) {
 	fmt.Fprintf(w, format, args...)

--- a/sloghandler_test.go
+++ b/sloghandler_test.go
@@ -1,0 +1,20 @@
+package cfft_test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/fujiwara/cfft"
+)
+
+func TestSlogHandler(t *testing.T) {
+	opt := &cfft.HandlerOptions{}
+	opt.Level = slog.LevelDebug
+	opt.Color = true
+	h := slog.New(cfft.NewLogHandler(os.Stderr, opt))
+	h.Debug("debug")
+	h.Info("info")
+	h.Warn("warn")
+	h.Error("error")
+}


### PR DESCRIPTION
When `os.Stderr` is connected to terminal, enable colored output.

<img width="389" alt="image" src="https://github.com/fujiwara/cfft/assets/67804/d10ae756-e002-4321-b634-43a45abfea8c">
