### PR TITLE
Initialize event.{headers,cookies,querystring} by empty object

### DIFF
--- a/functions_test.go
+++ b/functions_test.go
@@ -37,24 +37,29 @@ func (r *localRunner) Run(ctx context.Context, name, _ string, event []byte, log
 	return out, nil
 }
 
-func TestChainFunction(t *testing.T) {
+func TestLocalRunner(t *testing.T) {
+	dirs := []string{"funcv1", "funcv2", "chain", "partial-event"}
 	ctx := context.Background()
-	conf, err := cfft.LoadConfig(ctx, path.Join("testdata/chain/cfft.yaml"))
-	if err != nil {
-		t.Errorf("failed to load config: %v", err)
-	}
-	app, err := cfft.New(ctx, conf)
-	if err != nil {
-		t.Error(err)
-	}
-	code, err := app.Config().FunctionCode(ctx)
-	if err != nil {
-		t.Error(err)
-	}
-	app.SetRunner(&localRunner{code: code})
-	for _, cs := range app.Config().TestCases {
-		if err := app.RunTestCase(ctx, "chain", "", cs); err != nil {
-			t.Errorf("failed to test: %v", err)
-		}
+	for _, dir := range dirs {
+		t.Run(dir, func(t *testing.T) {
+			conf, err := cfft.LoadConfig(ctx, path.Join("testdata", dir, "cfft.yaml"))
+			if err != nil {
+				t.Errorf("failed to load config: %v", err)
+			}
+			app, err := cfft.New(ctx, conf)
+			if err != nil {
+				t.Error(err)
+			}
+			code, err := app.Config().FunctionCode(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+			app.SetRunner(&localRunner{code: code})
+			for _, cs := range app.Config().TestCases {
+				if err := app.RunTestCase(ctx, conf.Name, "", cs); err != nil {
+					t.Errorf("failed to test: %v", err)
+				}
+			}
+		})
 	}
 }

--- a/testdata/partial-event/cfft.yaml
+++ b/testdata/partial-event/cfft.yaml
@@ -1,0 +1,10 @@
+name: partial-event
+comment: ""
+function: function.js
+runtime: cloudfront-js-2.0
+testCases:
+  - name: default
+    event: event.json
+    expect: ""
+    ignore: ""
+    env: {}

--- a/testdata/partial-event/event.json
+++ b/testdata/partial-event/event.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.0",
+    "context": {
+        "eventType": "viewer-request"
+    },
+    "viewer": {
+        "ip": "1.2.3.4"
+    },
+    "request": {
+        "method": "GET",
+        "uri": "/index.html"
+    }
+}

--- a/testdata/partial-event/function.js
+++ b/testdata/partial-event/function.js
@@ -1,0 +1,7 @@
+async function handler(event) {
+  const request = event.request;
+  request.headers['cache-control'] = { value: 'private; no-cache' };
+  request.cookies = { 'cookie-name': { value: 'cookie-value' } };
+  request.querystring = { n: { value: '10' } };
+  return request;
+}

--- a/util.go
+++ b/util.go
@@ -102,6 +102,17 @@ func (r *CFFRequest) UnmarshalJSON(b []byte) error {
 	default:
 		return fmt.Errorf("invalid request object: %s", string(b))
 	}
+
+	// init by empty map if nil
+	if r.Headers == nil {
+		r.Headers = map[string]CFFValue{}
+	}
+	if r.QueryString == nil {
+		r.QueryString = map[string]CFFValue{}
+	}
+	if r.Cookies == nil {
+		r.Cookies = map[string]CFFCookieValue{}
+	}
 	return nil
 }
 


### PR DESCRIPTION
If that is nil, CFF may raise errors by null access.