### PR TITLE
Render test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,13 +503,29 @@ Before publishing the function, you need to run `cfft diff` to check the differe
 
 ### Render function code
 
-`cfft render` renders the function code to stdout.
+`cfft render` renders the function code or event object or expect object to STDOUT.
+
+```
+Usage: cfft render [<target>]
+
+render function code
+
+Arguments:
+  [<target>]    render target (function,event,expect)
+
+Flags:
+       --test-case=""          test case name (for target event or expect)
+```
 
 ```console
 $ cfft render
 ```
 
 You can use `cfft render` to check the function code after rendering the template syntax.
+
+`cfft render event --test-case=foo` renders the event object of the test case named 'foo'.
+
+The `--test-case` flag is available only for the `event` and `expect` targets. If `--test-case` is not specified, cfft renders the event or expect object of first test case.
 
 ## Template syntax
 

--- a/cfft.go
+++ b/cfft.go
@@ -147,7 +147,7 @@ func (app *CFFT) TestFunction(ctx context.Context, opt *TestCmd) error {
 			slog.Debug(f("skipping test case %s", testCase.Identifier()))
 			continue
 		}
-		if err := app.RunTestCase(ctx, app.config.Name, etag, testCase); err != nil {
+		if err := app.RunTestCase(ctx, etag, testCase); err != nil {
 			fail++
 			e := fmt.Errorf("failed to run test case %s, %w", testCase.Identifier(), err)
 			slog.Error(e.Error())
@@ -296,10 +296,10 @@ func (app *CFFT) associateKVS(ctx context.Context, fc *types.FunctionConfig) (bo
 	return associated, nil
 }
 
-func (app *CFFT) RunTestCase(ctx context.Context, name, etag string, cs *TestCase) error {
+func (app *CFFT) RunTestCase(ctx context.Context, etag string, cs *TestCase) error {
 	logger := slog.With("testcase", cs.Identifier())
 
-	output, err := app.runner.Run(ctx, name, etag, cs.EventBytes(), logger)
+	output, err := app.runner.Run(ctx, app.config.Name, etag, cs.EventBytes(), logger)
 	if err != nil {
 		return fmt.Errorf("failed to run test function, %w", err)
 	}
@@ -313,6 +313,7 @@ type CFFRunner struct {
 
 func (r *CFFRunner) Run(ctx context.Context, name, etag string, event []byte, logger *slog.Logger) ([]byte, error) {
 	logger.Info("testing function", "etag", etag)
+	logger.Debug(f("event object: %s", string(event)))
 
 	// retry policy for returning 0 ComputeUtilization
 	policy := retry.Policy{

--- a/functions_test.go
+++ b/functions_test.go
@@ -56,7 +56,7 @@ func TestLocalRunner(t *testing.T) {
 			}
 			app.SetRunner(&localRunner{code: code})
 			for _, cs := range app.Config().TestCases {
-				if err := app.RunTestCase(ctx, conf.Name, "", cs); err != nil {
+				if err := app.RunTestCase(ctx, "test-etag", cs); err != nil {
 					t.Errorf("failed to test: %v", err)
 				}
 			}

--- a/render.go
+++ b/render.go
@@ -3,12 +3,26 @@ package cfft
 import (
 	"context"
 	"fmt"
+	"log/slog"
 )
 
 type RenderCmd struct {
+	Target   string `arg:"" help:"render target (function,event,expect)" default:"function" enum:"function,event,expect"`
+	TestCase string `cmd:"" help:"test case name (for target event or expect)" default:""`
 }
 
 func (app *CFFT) Render(ctx context.Context, opt *RenderCmd) error {
+	switch opt.Target {
+	case "function", "": // default target
+		return app.renderFunction(ctx)
+	case "event", "expect":
+		return app.renderTestCase(ctx, opt)
+	default:
+		return fmt.Errorf("invalid target %s", opt.Target)
+	}
+}
+
+func (app *CFFT) renderFunction(ctx context.Context) error {
 	localCode, err := app.config.FunctionCode(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to read function code, %w", err)
@@ -17,4 +31,27 @@ func (app *CFFT) Render(ctx context.Context, opt *RenderCmd) error {
 		return fmt.Errorf("failed to write function code into STDOUT, %w", err)
 	}
 	return nil
+}
+
+func (app *CFFT) renderTestCase(ctx context.Context, opt *RenderCmd) error {
+	for _, tc := range app.config.TestCases {
+		// if test case name is empty, render first test case
+		if tc.Name == opt.TestCase || opt.TestCase == "" {
+			var b []byte
+			switch opt.Target {
+			case "event":
+				b = tc.EventBytes()
+			case "expect":
+				b = tc.ExpectBytes()
+			default:
+				return fmt.Errorf("invalid target %s", opt.Target)
+			}
+			slog.Info(f("rendering %s of test case %s", opt.Target, tc.Name))
+			if _, err := app.stdout.Write(b); err != nil {
+				return fmt.Errorf("failed to write %s into STDOUT, %w", opt.Target, err)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("test case %s not found", opt.TestCase)
 }

--- a/testdata/partial-event/cfft.yaml
+++ b/testdata/partial-event/cfft.yaml
@@ -5,6 +5,6 @@ runtime: cloudfront-js-2.0
 testCases:
   - name: default
     event: event.json
-    expect: ""
+    expect: expect.json
     ignore: ""
     env: {}

--- a/testdata/partial-event/expect.json
+++ b/testdata/partial-event/expect.json
@@ -1,0 +1,15 @@
+{
+    "request": {
+        "method": "GET",
+        "uri": "/index.html",
+        "headers": {
+            "cache-control": { "value": "private; no-cache" }
+        },
+        "cookies": {
+            "cookie-name": { "value": "cookie-value" }
+        },
+        "querystring": {
+            "n": { "value": "10" }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds 'target' to `cfft render`.

```
Usage: cfft render [<target>]

render function code

Arguments:
  [<target>]    render target (function,event,expect)

Flags:
       --test-case=""          test case name (for target event or expect)
```

`cfft render event --test-case=foo` renders the event object of the test case named 'foo'.

The `--test-case` flag is available only for the `event` and `expect` targets. If `--test-case` is not specified, cfft renders the event or expect object of first test case.
