### PR TITLE
add cfft tf --resource-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,8 @@ The variable's default value is not parsed as Terraform's interpolation syntax. 
 }
 ```
 
+`cfft tf --resource-name foo` outputs the JSON with the tf resource name `foo` instead of the function name.
+
 ### Generate JSON for Terraform external data sources
 
 `cfft tf --external` command outputs a JSON for Terraform [external data sources](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external).

--- a/examples/true-client-ip/function.js
+++ b/examples/true-client-ip/function.js
@@ -7,7 +7,7 @@ async function handler(event) {
   const request = event.request;
   const clientIP = event.viewer.ip;
   const hostname = (await kvsHandle.exists(clientIP)) ? await kvsHandle.get(clientIP) : 'unknown';
-
+  console.log(`clientIP: ${clientIP}, hostname: ${hostname}`);
   request.headers['true-client-ip'] = { value: clientIP };
   request.headers['x-hostname'] = { value: hostname };
   return request;

--- a/examples/true-client-ip/no-cache.js
+++ b/examples/true-client-ip/no-cache.js
@@ -1,0 +1,3 @@
+async function handler(event) {
+  eturn event.reques;
+}

--- a/tf_test.go
+++ b/tf_test.go
@@ -12,13 +12,29 @@ import (
 	"github.com/fujiwara/cfft"
 )
 
+var TFResourceCases = []struct {
+	Dir          string
+	ResourceName string
+}{
+	{Dir: "funcv1", ResourceName: ""},
+	{Dir: "funcv1", ResourceName: "named-v1"},
+	{Dir: "funcv2", ResourceName: ""},
+	{Dir: "funcv2", ResourceName: "named-v2"},
+}
+
 func TestTFResource(t *testing.T) {
 	ctx := context.Background()
-	for _, name := range []string{"funcv1", "funcv2"} {
-		t.Run("tf-resource-"+name, func(t *testing.T) {
-			conf, err := cfft.LoadConfig(ctx, path.Join("testdata", name, "/cfft.yaml"))
+	for _, cs := range TFResourceCases {
+		t.Run("tf-resource-"+cs.Dir, func(t *testing.T) {
+			var rname string
+			conf, err := cfft.LoadConfig(ctx, path.Join("testdata", cs.Dir, "/cfft.yaml"))
 			if err != nil {
 				t.Fatal(err)
+			}
+			if cs.ResourceName != "" {
+				rname = cs.ResourceName
+			} else {
+				rname = conf.Name
 			}
 			app, err := cfft.New(ctx, conf)
 			if err != nil {
@@ -27,14 +43,19 @@ func TestTFResource(t *testing.T) {
 			b := &bytes.Buffer{}
 			app.SetStdout(b)
 			publish := true
-			if err := app.RunTF(ctx, &cfft.TFCmd{External: false, Publish: &publish}); err != nil {
+			opt := &cfft.TFCmd{
+				External:     false,
+				Publish:      &publish,
+				ResourceName: cs.ResourceName,
+			}
+			if err := app.RunTF(ctx, opt); err != nil {
 				t.Fatal(err)
 			}
 			var m map[string]any
 			if err := json.Unmarshal(b.Bytes(), &m); err != nil {
 				t.Log("failed to parse json", err)
 			}
-			code := m["resource"].(map[string]any)["aws_cloudfront_function"].(map[string]any)[conf.Name].(map[string]any)["code"].(string)
+			code := m["resource"].(map[string]any)["aws_cloudfront_function"].(map[string]any)[rname].(map[string]any)["code"].(string)
 			var rawCode string
 			if strings.Contains(code, "${var.") {
 				varName := strings.TrimSuffix(strings.TrimPrefix(code, "${var."), "}")


### PR DESCRIPTION
to specify terraform resource name by flags.

`cfft tf --resource-name foo` outputs the JSON with the tf resource name `foo` instead of the function name.
