### PR TITLE
ReadFile evaluates template after jsonnet/yaml parsed

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -8,3 +8,11 @@ func (app *CFFT) Config() *Config {
 func (app *CFFT) SetRunner(r FunctionRunner) {
 	app.runner = r
 }
+
+func (tc *TestCase) GetEvent() *CFFEvent {
+	return tc.event
+}
+
+func (tc *TestCase) GetExpect() *CFFExpect {
+	return tc.expect
+}

--- a/testcase_test.go
+++ b/testcase_test.go
@@ -21,6 +21,10 @@ func TestSetup(t *testing.T) {
 			if err != nil {
 				t.Errorf("Setup returned an error: %v", err)
 			}
+			ev := testCase.GetEvent()
+			if ev.Version != "1.0" {
+				t.Errorf("GetEvent returned unexpected version: %v", ev.Version)
+			}
 		})
 	}
 }

--- a/testdata/libs/event.libsonnet
+++ b/testdata/libs/event.libsonnet
@@ -1,3 +1,3 @@
 {
-  version: '1.0',
+  version: '{{ env `VERSION` `1.0` }}',
 }


### PR DESCRIPTION
Evaluations were not affected for jsonnet import files.

This PR breaks the compatibility of loading jsonnet files including template syntax.

For example, If the jsonnet file extracts non-string values (numbers or booleans) by template syntax, the file becomes the wrong jsonnet file as below.

```jsonnet
{
  "is_ok": {{ env `IS_OK` `true` }}
}
```

But, CFF event and CFF expect files do not contain booleans or numbers(excludes `response.statusCode`). So this change is acceptable for convenience.

And there is a workaround below.

```jsonnet
{
  statusCode: std.parseInt('{{ env `STATUS_CODE` `200` }}')
}
```
