### PR TITLE
add hash of code to tf comment for detecting code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ cff.tf.json
         "name": "some-function",
         "runtime": "cloudfront-js-2.0",
         "code": "....(function code)....",
-        "comment": "comment of the function",
+        "comment": "comment of the function // sha256:...",
       }
     }
   }
@@ -667,6 +667,8 @@ The variable's default value is not parsed as Terraform's interpolation syntax. 
       "some-function": {
         "name": "some-function",
         "code": "${var.code_of_some-function}",
+        "comment": "comment of the function // sha256:...",
+        "publish": true,
         "runtime": "cloudfront-js-2.0"
       }
     }
@@ -685,7 +687,7 @@ $ cfft tf --external
 {
   "name": "some-function",
   "code": "....(function code)....",
-  "comment": "comment of the function",
+  "comment": "comment of the function // sha256:...",
   "runtime": "cloudfront-js-2.0"
 }
 ```

--- a/tf.go
+++ b/tf.go
@@ -2,6 +2,7 @@ package cfft
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -46,6 +47,11 @@ func (app *CFFT) RunTF(ctx context.Context, opt *TFCmd) error {
 	if err != nil {
 		return fmt.Errorf("failed to read function code, %w", err)
 	}
+	// add hash of code to comment for detecting code change
+	h := sha256.New()
+	h.Write(code)
+	comment := app.config.Comment + fmt.Sprintf("// sha256:%x", h.Sum(nil))
+
 	localCode := string(code)
 	var rname string
 	if opt.ResourceName != "" {
@@ -56,7 +62,7 @@ func (app *CFFT) RunTF(ctx context.Context, opt *TFCmd) error {
 	out := TFOutout{
 		Name:    rname,
 		Runtime: app.config.Runtime,
-		Comment: app.config.Comment,
+		Comment: comment,
 	}
 	enc := json.NewEncoder(app.stdout)
 	enc.SetIndent("", "  ")

--- a/tf_test.go
+++ b/tf_test.go
@@ -107,7 +107,7 @@ func TestTFExternalData(t *testing.T) {
 			if m["runtime"] != string(conf.Runtime) {
 				t.Error("external data source runtime is not same as cfft.yaml")
 			}
-			if m["comment"] != string(conf.Comment) {
+			if !strings.HasPrefix(m["comment"], conf.Comment+"// sha256:") {
 				t.Error("external data source comment is not same as cfft.yaml")
 			}
 		})


### PR DESCRIPTION
Terraform aws_cloudfront_fuction resource compares the function code changes by DEVELOPMENT stage and local.

https://github.com/hashicorp/terraform-provider-aws/blob/574bfe831701673af95c414412b76350c43244cc/internal/service/cloudfront/function.go#L139-L142

If `cfft test` has been run before `terraform plan`, the code of DEVELOPMENT stage is changed by cfft. So Terraform cannot find diff in the code changes and outputs the "No changes" plan even if `publish=true` is specified.

This PR enables the detection of code changes by embedding the hash of code into the comment strings. Even if the comment is changed only, `terraform apply` will update the function comment and publish the code to the LIVE stage by the `publish=true` attribute.