### PR TITLE
Add a cfft header comment (//cfft:{sha256}) into the generated code.

### DIFF
--- a/cfft.go
+++ b/cfft.go
@@ -19,8 +19,6 @@ import (
 	"github.com/shogo82148/go-retry"
 )
 
-var Stage = types.FunctionStageDevelopment
-
 var Version = "dev"
 
 var logLevel = new(slog.LevelVar)
@@ -131,7 +129,7 @@ func (app *CFFT) TestFunction(ctx context.Context, opt *TestCmd) error {
 	if err := opt.Setup(); err != nil {
 		return err
 	}
-	code, err := app.config.FunctionCode(ctx)
+	code, err := app.config.FunctionCode(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to load function code, %w", err)
 	}
@@ -200,7 +198,7 @@ func (app *CFFT) prepareFunction(ctx context.Context, name string, code []byte, 
 
 	res, err := app.cloudfront.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
 		Name:  aws.String(name),
-		Stage: Stage,
+		Stage: types.FunctionStageDevelopment,
 	})
 	if err != nil {
 		var notFound *types.NoSuchFunctionExists
@@ -235,7 +233,7 @@ func (app *CFFT) prepareFunction(ctx context.Context, name string, code []byte, 
 
 		if res, err := app.cloudfront.GetFunction(ctx, &cloudfront.GetFunctionInput{
 			Name:  aws.String(name),
-			Stage: Stage,
+			Stage: types.FunctionStageDevelopment,
 		}); err != nil {
 			return "", fmt.Errorf("failed to describe function, %w", err)
 		} else {
@@ -326,7 +324,7 @@ func (r *CFFRunner) Run(ctx context.Context, name, etag string, event []byte, lo
 		res, err := r.cloudfront.TestFunction(ctx, &cloudfront.TestFunctionInput{
 			Name:        aws.String(name),
 			IfMatch:     aws.String(etag),
-			Stage:       Stage,
+			Stage:       types.FunctionStageDevelopment,
 			EventObject: event,
 		})
 		if err != nil {

--- a/diff.go
+++ b/diff.go
@@ -34,7 +34,7 @@ func (app *CFFT) diffFunctionConfig(ctx context.Context) error {
 	var remote string
 	res, err := app.cloudfront.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
 		Name:  aws.String(name),
-		Stage: Stage,
+		Stage: types.FunctionStageDevelopment,
 	})
 	if err != nil {
 		var notFound *types.NoSuchFunctionExists
@@ -75,7 +75,7 @@ func (app *CFFT) diffFunctionCode(ctx context.Context) error {
 	var remoteCode []byte
 	res, err := app.cloudfront.GetFunction(ctx, &cloudfront.GetFunctionInput{
 		Name:  aws.String(name),
-		Stage: Stage,
+		Stage: types.FunctionStageDevelopment,
 	})
 	if err != nil {
 		var notFound *types.NoSuchFunctionExists
@@ -93,7 +93,7 @@ func (app *CFFT) diffFunctionCode(ctx context.Context) error {
 	if res != nil {
 		remote = aws.ToString(res.ETag)
 	}
-	localCode, err := app.config.FunctionCode(ctx)
+	localCode, err := app.config.FunctionCode(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read function code, %w", err)
 	}

--- a/functions_test.go
+++ b/functions_test.go
@@ -50,7 +50,7 @@ func TestLocalRunner(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			code, err := app.Config().FunctionCode(ctx)
+			code, err := app.Config().FunctionCode(ctx, nil)
 			if err != nil {
 				t.Error(err)
 			}

--- a/init.go
+++ b/init.go
@@ -66,7 +66,7 @@ func (app *CFFT) InitFunction(ctx context.Context, opt *InitCmd) error {
 	var kvsConfig *KeyValueStoreConfig
 	res, err := app.cloudfront.GetFunction(ctx, &cloudfront.GetFunctionInput{
 		Name:  aws.String(name),
-		Stage: Stage,
+		Stage: types.FunctionStageDevelopment,
 	})
 	if err != nil {
 		var notFound *types.NoSuchFunctionExists
@@ -82,7 +82,7 @@ func (app *CFFT) InitFunction(ctx context.Context, opt *InitCmd) error {
 		slog.Info("detecting kvs association...")
 		res, err := app.cloudfront.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
 			Name:  aws.String(name),
-			Stage: Stage,
+			Stage: types.FunctionStageDevelopment,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to describe function, %w", err)

--- a/publish.go
+++ b/publish.go
@@ -21,7 +21,7 @@ func (app *CFFT) PublishFunction(ctx context.Context, opt *PublishCmd) error {
 	var remoteCode []byte
 	if res, err := app.cloudfront.GetFunction(ctx, &cloudfront.GetFunctionInput{
 		Name:  aws.String(name),
-		Stage: Stage,
+		Stage: types.FunctionStageDevelopment,
 	}); err != nil {
 		var notFound *types.NoSuchFunctionExists
 		if errors.As(err, &notFound) {
@@ -34,7 +34,7 @@ func (app *CFFT) PublishFunction(ctx context.Context, opt *PublishCmd) error {
 	}
 	slog.Info(f("function %s found", name))
 
-	localCode, err := app.config.FunctionCode(ctx)
+	localCode, err := app.config.FunctionCode(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read function code, %w", err)
 	}

--- a/render.go
+++ b/render.go
@@ -23,7 +23,7 @@ func (app *CFFT) Render(ctx context.Context, opt *RenderCmd) error {
 }
 
 func (app *CFFT) renderFunction(ctx context.Context) error {
-	localCode, err := app.config.FunctionCode(ctx)
+	localCode, err := app.config.FunctionCode(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("failed to read function code, %w", err)
 	}

--- a/tf_test.go
+++ b/tf_test.go
@@ -90,7 +90,7 @@ func TestTFExternalData(t *testing.T) {
 			b := &bytes.Buffer{}
 			app.SetStdout(b)
 			publish := true
-			if err := app.RunTF(ctx, &cfft.TFCmd{External: true, Publish: &publish}); err != nil {
+			if err := app.RunTF(ctx, &cfft.TFCmd{External: true, Publish: &publish, Live: false}); err != nil {
 				t.Fatal(err)
 			}
 			var m map[string]string // for external data source, all values must be string
@@ -98,6 +98,9 @@ func TestTFExternalData(t *testing.T) {
 				t.Log("failed to parse json", err)
 			}
 			code, _ := os.ReadFile(path.Join("testdata", name, "function.js"))
+			// compare code, name, runtime, comment
+			// remove header comment
+			m["code"] = cfft.RegexpCodeHeaderComment.ReplaceAllString(m["code"], "")
 			if m["code"] != string(code) {
 				t.Error("external data source code is not same as function.js")
 			}

--- a/util.go
+++ b/util.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -510,4 +511,16 @@ func textToHTTPResponse(text string) (*http.Response, error) {
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	return resp, nil
+}
+
+// RemoveHeaderComment is a regexp to remove header comment from function code
+var RegexpCodeHeaderComment = regexp.MustCompile(`//cfft:[^\n]+\n`)
+
+// RemoveHeaderComment removes header comment from function code
+func RemoveHeaderComment(code []byte) []byte {
+	found := RegexpCodeHeaderComment.Find(code)
+	if found != nil {
+		return bytes.Replace(code, found, nil, 1)
+	}
+	return code
 }


### PR DESCRIPTION
This comment helps detect changes in the function code.

Normally, the hash is generated from the local code. Only when running `cfft tf`, the hash is generated from the LIVE code. So, Terraform can detect the changes in code between the local and the LIVE through `cfft tf.`