### PR TITLE
Tf kvs associations

### DIFF
--- a/testcase.go
+++ b/testcase.go
@@ -139,7 +139,7 @@ func localEnv(key, value string) func() {
 	prevValue, ok := os.LookupEnv(key)
 
 	if err := os.Setenv(key, value); err != nil {
-		slog.Error("cannot set environment variable: %v", err)
+		slog.Error("cannot set environment variable:", "error", err)
 		panic(err)
 	}
 

--- a/tf.go
+++ b/tf.go
@@ -39,11 +39,12 @@ type TFCFF struct {
 }
 
 type TFOutout struct {
-	Name    string                `json:"name"`
-	Code    string                `json:"code"`
-	Runtime types.FunctionRuntime `json:"runtime"`
-	Comment string                `json:"comment"`
-	Publish *bool                 `json:"publish,omitempty"`
+	Name                      string                `json:"name"`
+	Code                      string                `json:"code"`
+	Runtime                   types.FunctionRuntime `json:"runtime"`
+	Comment                   string                `json:"comment"`
+	KeyValueStoreAssociations []string              `json:"key_value_store_associations,omitempty"`
+	Publish                   *bool                 `json:"publish,omitempty"`
 }
 
 func (app *CFFT) RunTF(ctx context.Context, opt *TFCmd) error {
@@ -63,6 +64,10 @@ func (app *CFFT) RunTF(ctx context.Context, opt *TFCmd) error {
 		Runtime: app.config.Runtime,
 		Comment: app.config.Comment,
 	}
+	if app.cfkvsArn != "" {
+		out.KeyValueStoreAssociations = []string{app.cfkvsArn}
+	}
+
 	enc := json.NewEncoder(app.stdout)
 	enc.SetIndent("", "  ")
 


### PR DESCRIPTION
Terraform aws provider `aws_cloudfront_function` supports `key_value_store_associations`.

`cfft tf` also outputs the element.